### PR TITLE
Hot fix: Remove SSL dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /build
 
 COPY ./pom.xml ./
 COPY ./src ./src
-COPY ./build_ssl.sh ./
 
 RUN mvn clean package -DskipTests
 


### PR DESCRIPTION
# Description:

Quick update to remove `build_ssl.sh` from Dockerfile pipeline

# Changes

- Updated Dockerfile